### PR TITLE
chore: add web app TypeScript 6 config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "rsbuild",
     "build": "rsbuild build",
-    "preview": "rsbuild preview"
+    "preview": "rsbuild preview",
+    "test": "pnpm build"
   },
   "packageManager": "pnpm@10.12.4",
   "dependencies": {
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.7.3",
-    "@rsbuild/plugin-react": "^1.4.5"
+    "@rsbuild/plugin-react": "^1.4.5",
+    "typescript": "^6.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@rsbuild/plugin-react':
         specifier: ^1.4.5
         version: 1.4.5(@rsbuild/core@1.7.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -177,6 +180,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
 snapshots:
 
@@ -338,3 +346,5 @@ snapshots:
   stackframe@1.3.4: {}
 
   tslib@2.8.1: {}
+
+  typescript@6.0.2: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2023",
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
+    "allowJs": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a web-app-friendly TypeScript 6 config with `module: "ESNext"` and `moduleResolution: "Bundler"`
- upgrade TypeScript to `^6.0.2`

## Testing
- `pnpm i`
- `pnpm build`

## Related Links
- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2
